### PR TITLE
Make WithDebug take a boolean value

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ import (
 )
 
 func main() {
-    log, err := logger.New(os.Stdout, logger.WithDebug(), logger.WithErrorOutput(os.Stderr))
+    log, err := logger.New(os.Stdout, logger.WithDebug(true), logger.WithErrorOutput(os.Stderr))
     if err != nil {
         os.Exit(1)
     }

--- a/examples/complete_advanced/main.go
+++ b/examples/complete_advanced/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	log, err := logger.New(os.Stdout, logger.WithDebug(), logger.WithErrorOutput(os.Stderr))
+	log, err := logger.New(os.Stdout, logger.WithDebug(true), logger.WithErrorOutput(os.Stderr))
 	if err != nil {
 		os.Exit(1)
 	}

--- a/examples/simple_logger/main.go
+++ b/examples/simple_logger/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	log, err := logger.New(os.Stdout, logger.WithDebug(), logger.WithErrorOutput(os.Stderr))
+	log, err := logger.New(os.Stdout, logger.WithDebug(true), logger.WithErrorOutput(os.Stderr))
 	if err != nil {
 		os.Exit(1)
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -33,9 +33,9 @@ func New(w io.Writer, options ...func(*Logger)) (*Logger, error) {
 }
 
 // WithDebug sets the logger debug mode to true.
-func WithDebug() func(*Logger) {
+func WithDebug(enabled bool) func(*Logger) {
 	return func(logger *Logger) {
-		logger.debug = true
+		logger.debug = enabled
 	}
 }
 


### PR DESCRIPTION
## Goal of this PR

It's better for developers to instantiate their loggers like:

```
logger, err := logger.New(os.Stdout, logger.WithDebug(flag.Debug))
```

Rather than to add logic to only add the `logger.WithDebug` option when their debug flag is set to true.

Fixes #11 

## How to test it

* `go test ./...`
* Run the examples