### PR TITLE
Improve godoc documentation

### DIFF
--- a/disgo.go
+++ b/disgo.go
@@ -1,10 +1,9 @@
 // Package disgo is a logging and prompting library for
 // modern command line interfaces.
 //
-// It is NOT a substitute for a structured logger
-// in an application or a microservice, since it is
-// completely centered around user interaction and
-// user-friendly terminal interfaces.
+// It does not provide sutructed logging and is not built
+// with performance in mind, since it is aimed at building
+// user-friendly command line interfaces, and not applications.
 //
 // The packages that compose disgo can be used independently.
 //

--- a/disgo.go
+++ b/disgo.go
@@ -1,0 +1,22 @@
+// Package disgo is a logging and prompting library for
+// modern command line interfaces.
+//
+// It is NOT a substitute for a structured logger
+// in an application or a microservice, since it is
+// completely centered around user interaction and
+// user-friendly terminal interfaces.
+//
+// The packages that compose disgo can be used independently.
+//
+// The logger pakage (github.com/Ullaakut/disgo/logger) is a
+// simplified logger which only handles two basic log levels
+// (standard and debug).
+//
+// The prompter package (github.com/Ullaakut/disgo/prompter)
+// is a simple user prompter that asks users for input data
+// or confirmations.
+//
+// The symbol package (github.com/Ullaakut/disgo/symbol)
+// provides access to cherry-picked UTF-8 symbols that are
+// useful for making user-friendly command line interfaces.
+package disgo

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,3 +1,5 @@
+// Package logger is a simplified logger which only
+// handles two basic log levels.
 package logger
 
 import (
@@ -11,11 +13,14 @@ import (
 // It writes the output on a given io.Writer
 // and can toggle debug logs and have an error writer.
 type Logger struct {
+	// Writer on which the Info and Debug logs are written.
 	standardOutput io.Writer
-	errorOutput    io.Writer
+	// Writer on which the Error logs are written.
+	errorOutput io.Writer
 
-	debug       bool
-	logFilePath string
+	// Whether or not Debug logs are enabled. If this is
+	// disabled, Debug logs are not shown to the user.
+	debug bool
 }
 
 // New creates a new Logger and binds the given writer to its outputs.

--- a/prompter/prompter.go
+++ b/prompter/prompter.go
@@ -1,3 +1,5 @@
+// Package prompter is a simple user prompter that asks users
+// for input data or confirmations.
 package prompter
 
 import (
@@ -7,9 +9,18 @@ import (
 
 // Prompter prompts users to let them input data, and parses it.
 type Prompter struct {
+	// Writer on which the prompt's label and choices are
+	// written when prompting them.
 	writer io.Writer
+
+	// Reader from which the user's response to the prompt is
+	// read.
 	reader *bufio.Reader
 
+	// Whether or not this prompter is running in a TTY. If this is
+	// set to false, this prompter will return default values instead
+	// of prompting users, and it will return errors if no default values
+	// are set.
 	interactive bool
 }
 

--- a/prompter/prompter.go
+++ b/prompter/prompter.go
@@ -17,10 +17,10 @@ type Prompter struct {
 	// read.
 	reader *bufio.Reader
 
-	// Whether or not this prompter is running in a TTY. If this is
-	// set to false, this prompter will return default values instead
-	// of prompting users, and it will return errors if no default values
-	// are set.
+	// Whether or not this prompter should be interactive. If this is
+	// set to false, the prompter will never prompt the user and always
+	// return default values. This can be useful for running this code
+	// outside of a TTY for example.
 	interactive bool
 }
 

--- a/symbol/symbol.go
+++ b/symbol/symbol.go
@@ -1,5 +1,7 @@
-// Package symbol contains a few UTF-8 symbols to be used in your user interface.
-// They are all colorless so that they can be used along with `disgo/logger`'s formatting helpers.
+// Package symbol contains a few cherry-picked UTF-8 symbols to be
+// used to build user-friendly command-line interfaces.
+// They are all colorless so that they can be used along
+// with `disgo/logger`'s formatting helpers.
 package symbol
 
 const (


### PR DESCRIPTION
## Goal of this PR

This PR adds a bunch of comments to packages and attributes in order to improve documentation overall, and it also adds a `disgo` package at the root of the repository for documentation purposes (in a similar way to what [testify](https://godoc.org/github.com/stretchr/testify) does for example)

Fixes #13 
Closes #8 

## How to test it

- Ensure that I didn't make too many spelling mistakes
- Feel free to improve sentences / suggest better documentation / more precise vocabulary