### PR TITLE
Fix Important() format

### DIFF
--- a/logger/format.go
+++ b/logger/format.go
@@ -15,9 +15,9 @@ var (
 	// to represent a log of low importance for the user.
 	Trace = color.New(color.FgHiWhite, color.Faint).SprintFunc()
 
-	// Important colors a message in bold white to represent an important
+	// Important colors a message in bold to represent an important
 	// information.
-	Important = color.New(color.FgHiWhite, color.Bold).SprintFunc()
+	Important = color.New(color.Bold).SprintFunc()
 
 	// Link colors a message in underlined blue to represent a clickable link.
 	Link = color.New(color.FgBlue, color.Underline).SprintFunc()

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -46,10 +46,12 @@ func WithErrorOutput(w io.Writer) func(*Logger) {
 	}
 }
 
-// WithNoColors disables colors in the logger.
-func WithNoColors() func(*Logger) {
+// WithColors sets the use of colors in the logger. By default, whether or not
+// colors are enabled depends on the user's TTY, but this option can be used
+// to force colors to be enabled or disabled.
+func WithColors(enabled bool) func(*Logger) {
 	return func(_ *Logger) {
-		color.NoColor = true
+		color.NoColor = !enabled
 	}
 }
 


### PR DESCRIPTION
## Goal of this PR

- Rename `colors.go` to `format.go` to show that the focus is on interface formatting and not especially on colors. Bold text or underlined text is also part of user interface and is not necessarily related to colors.
- Make `Important` formatting bold instead of bold white, in order to be compatible with light-themed terminals.
- Make the `WithColors` function easier to use and better documented (especially regarding the fact that colors might be disabled by default on some terminals).

Fixes #10 

## How to test it

- A code review should be sufficient 👍🏽